### PR TITLE
Typo fix: 'Priortize Loot' -> 'Priortize Attack'

### DIFF
--- a/ContextMenuOptions/src/ContextMenuOptions.ts
+++ b/ContextMenuOptions/src/ContextMenuOptions.ts
@@ -23,7 +23,7 @@ export default class ContextMenuOptions extends Plugin {
         };
 
         this.settings.prioritizeAttack = {
-            text: 'Prioritize Loot',
+            text: 'Prioritize Attack',
             type: 0,
             value: false,
             callback: this.enablePrioritizeAttackChanged,


### PR DESCRIPTION
Typo fix: 'Priortize Loot' -> 'Priortize Attack'